### PR TITLE
Add registration validation and more activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,7 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    # Intellectual Activities
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -33,11 +34,87 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "Science Olympiad": {
+        "description": "Prepare for competitive science events and experiments",
+        "schedule": "Saturdays, 9:00 AM - 11:00 AM",
+        "max_participants": 15,
+        "participants": ["alice@mergington.edu", "bob@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills through competitive debates",
+        "schedule": "Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["carlos@mergington.edu"]
+    },
+    "Math Club": {
+        "description": "Explore advanced mathematics concepts and participate in competitions",
+        "schedule": "Thursdays, 3:45 PM - 5:15 PM",
+        "max_participants": 14,
+        "participants": ["jennifer@mergington.edu", "kevin@mergington.edu"]
+    },
+    "Robotics Team": {
+        "description": "Build and program robots for competitive robotics challenges",
+        "schedule": "Saturdays, 2:00 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["ryan@mergington.edu"]
+    },
+    
+    # Sports Activities
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball training and inter-school tournaments",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 6:00 PM",
+        "max_participants": 15,
+        "participants": ["marcus@mergington.edu", "sarah@mergington.edu"]
+    },
+    "Swimming Club": {
+        "description": "Swimming techniques, water safety, and competitive swimming",
+        "schedule": "Tuesdays and Thursdays, 6:00 AM - 7:30 AM",
+        "max_participants": 20,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Competitive soccer training and inter-school matches",
+        "schedule": "Tuesdays and Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 22,
+        "participants": ["diego@mergington.edu", "maria@mergington.edu"]
+    },
+    "Track and Field": {
+        "description": "Running, jumping, and throwing events for athletic development",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["james@mergington.edu", "natalie@mergington.edu", "victor@mergington.edu"]
+    },
+    
+    # Artistic Activities
+    "Drama Club": {
+        "description": "Acting, scriptwriting, and theatrical productions",
+        "schedule": "Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["elena@mergington.edu", "david@mergington.edu", "lisa@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Painting, drawing, sculpture and various visual arts techniques",
+        "schedule": "Saturdays, 1:00 PM - 4:00 PM",
+        "max_participants": 16,
+        "participants": ["maya@mergington.edu", "jackson@mergington.edu"]
+    },
+    "Music Band": {
+        "description": "Learn instruments and perform in school concerts and events",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 30,
+        "participants": ["sophia@mergington.edu", "lucas@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Photography Club": {
+        "description": "Learn photography techniques, digital editing, and showcase artistic vision",
+        "schedule": "Sundays, 10:00 AM - 1:00 PM",
+        "max_participants": 18,
+        "participants": ["rachel@mergington.edu", "ethan@mergington.edu"]
     }
 }
 
@@ -61,6 +138,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -20,11 +29,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsMarkup = details.participants.length
+          ? `<ul class="participants-list">
+              ${details.participants.map(p => `<li>${escapeHtml(p)}</li>`).join("")}
+             </ul>`
+          : `<p class="no-participants">No participants yet. Be the first!</p>`;
+
         activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
+          <h4>${escapeHtml(name)}</h4>
+          <p>${escapeHtml(details.description)}</p>
+          <p><strong>Schedule:</strong> ${escapeHtml(details.schedule)}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <div class="participants-title">Participants (${details.participants.length})</div>
+            ${participantsMarkup}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -63,6 +63,8 @@ section h3 {
   border: 1px solid #ddd;
   border-radius: 5px;
   background-color: #f9f9f9;
+  position: relative;
+  overflow: hidden;
 }
 
 .activity-card h4 {
@@ -72,6 +74,66 @@ section h3 {
 
 .activity-card p {
   margin-bottom: 8px;
+}
+
+/* Participants section */
+.activity-card .participants-section {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed #c5cae9;
+  animation: fadeIn 0.3s ease;
+}
+
+.activity-card .participants-title {
+  font-size: 0.9rem;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  color: #3949ab;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.activity-card .participants-title::before {
+  content: "👥";
+  font-size: 0.95rem;
+}
+
+.participants-list {
+  list-style: disc;
+  margin-left: 1.1rem;
+  display: block;
+}
+
+.participants-list li {
+  margin: 2px 0;
+  font-size: 0.85rem;
+  color: #444;
+  line-height: 1.3;
+  position: relative;
+}
+
+.participants-list li::marker {
+  color: #1a237e;
+}
+
+.no-participants {
+  font-size: 0.8rem;
+  font-style: italic;
+  color: #777;
+  margin: 4px 0 0 0;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .form-group {


### PR DESCRIPTION
This pull request expands the available student activities, improves the signup process, and enhances the user interface for displaying activity participants. The main changes include adding new intellectual, sports, and artistic activities, preventing duplicate signups, and updating the frontend to securely and attractively display participant lists for each activity.

**Activity data expansion:**

* Added multiple new activities to the `activities` dictionary in `src/app.py`, organized into intellectual (e.g., Science Olympiad, Debate Team), sports (e.g., Basketball Team, Swimming Club), and artistic (e.g., Drama Club, Art Studio) categories. Each activity includes a description, schedule, maximum participants, and a sample participant list. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R24) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R37-R117)

**Backend improvements:**

* Updated the `signup_for_activity` function in `src/app.py` to prevent students from signing up for the same activity more than once by raising an error if the user is already a participant.

**Frontend enhancements:**

* Introduced an `escapeHtml` function in `src/static/app.js` to sanitize user-generated content before rendering, preventing XSS vulnerabilities.
* Updated the activity card rendering in `src/static/app.js` to display a list of current participants for each activity or a message if there are none, using the new `escapeHtml` function for all dynamic content.

**Styling updates:**

* Added new CSS styles in `src/static/styles.css` to visually distinguish the participants section within each activity card, including styling for participant lists, titles, and an animation for section appearance. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R66-R67) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R79-R138)